### PR TITLE
Fix for modern Helm v2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM linkyard/docker-helm:2.9.1
+FROM linkyard/alpine-helm:2.17.0
 
 RUN apk add --update --upgrade --no-cache jq bash
 

--- a/assets/common.sh
+++ b/assets/common.sh
@@ -2,7 +2,7 @@
 set -e
 
 init_helm() {
-  helm init --client-only > /dev/null
+  helm init --stable-repo-url=https://charts.helm.sh/stable --client-only > /dev/null
   helm version --client
 }
 


### PR DESCRIPTION
- Updates Helm v2 to 2.17.0
- Adjusts the init command for new stable URL

Fixes #8

I haven't used Concourse in a few years so I can't properly test this completely, but I was able to:
1. Build the new image using latest 2
2. Run the `check` command to init helm:
<img width="957" alt="Screen Shot 2021-01-08 at 4 13 56 PM" src="https://user-images.githubusercontent.com/7211830/104064941-d7c32200-51cc-11eb-88e4-677911c6ddf9.png">
